### PR TITLE
Updating instructions for Logic Apps - Schedule not listed as an option

### DIFF
--- a/docs/telemetry-analytics.md
+++ b/docs/telemetry-analytics.md
@@ -45,7 +45,7 @@ Automatic email notification of unanswered questions (Time to Setup -- 10 Minute
     ![](.//media/image29.png)
 
 2.  Once created, click on **Blank Logic App** and select **Schedule**
-    as the trigger
+    as the trigger. (Select the **All** tab if you do not see **Schedule** as an otion under the For You tab)
 
     ![](.//media/image30.png)
 


### PR DESCRIPTION
The Schedule option was not visible for me in the For You tab so I had to go to the All tab. This may throw some users off so I included that direction in parenthesis).